### PR TITLE
Feature/container user node

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,30 +1,41 @@
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-16
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-18
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install --no-install-recommends java-common zip \
-    && wget https://corretto.aws/downloads/latest/amazon-corretto-8-x64-linux-jdk.deb \
-    && dpkg --install amazon-corretto-8-x64-linux-jdk.deb \
-    && wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \
-    && unzip awscli-exe-linux-x86_64.zip \
-    && ./aws/install \
-    # Clean up
-    && rm -f awscli-exe-linux-x86_64.zip \
-    && rm -f amazon-corretto-8-x64-linux-jdk.deb \
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+  && wget https://corretto.aws/downloads/latest/amazon-corretto-8-x64-linux-jdk.deb \
+  && dpkg --install amazon-corretto-8-x64-linux-jdk.deb \
+  && wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \
+  && unzip awscli-exe-linux-x86_64.zip \
+  && ./aws/install \
+  # Clean up
+  && rm -f awscli-exe-linux-x86_64.zip \
+  && rm -f amazon-corretto-8-x64-linux-jdk.deb \
+  && apt-get autoremove -y \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
 ENV DEBIAN_FRONTEND=dialog
 
-ENV NVM_DIR /usr/local/share/nvm
-ENV NODE_VERSION 16.15.1
-
+# docker imageの方で既にnvmは入っている
+# rootからnodeユーザーになっている
+# ENV NVM_DIR /usr/local/share/nvm
+# ENV NODE_VERSION 16.15.1
+#
 # Install nvm with node and npm
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \
-    && . $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && nvm use default
+# RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \
+#   && . $NVM_DIR/nvm.sh \
+#   && nvm install $NODE_VERSION \
+#   && nvm alias default $NODE_VERSION \
+#   && nvm use default
+# 
 
-RUN curl -o- https://get.volta.sh | bash 
+# 自分が使いたいnodeバージョンをインストール,  use pre Installed nvm. install use node veresion.
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} && nvm alias default $NODE_VERSION && nvm use default"
 
+# voltaは自前でインストールする
+RUN su node -c "curl -o- https://get.volta.sh | bash "
+
+RUN su node -c "npm install --global @aws-amplify/cli@12.3.0 --unsafe-perm=true"
 WORKDIR /workspaces
+
+# nodeユーザー向け
+RUN chown node:node /workspaces

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,54 +1,57 @@
 {
-	"name": "vue amplify",
-
-	"dockerFile": "Dockerfile",
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
-
-	// Add the IDs of extensions you want installed when the container is created.
-	// Git Extension Pack => "donjayamanne.git-extension-pack"
-	// GraphQL => "graphql.vscode-graphql"
-	// GraphQL for VSCode => kumar-harsh.graphql-for-vscode
-	"extensions": [
-		"dbaeumer.vscode-eslint",
-		"mhutchie.git-graph",
-		"eamodio.gitlens"
-		
-	],
-
-	// Mount ~/.aws directory for AWS Amplify CLI and AWS CLI access
-	// Mount ~/.ssh directory for Git Repository GitHub, GitLab ...
-	//"source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/root/.aws,type=bind,consistency=cached",
-	//"source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
-	"mounts": [
-		"source=${localWorkspaceFolder}/aws,target=/root/.aws,type=bind,consistency=cached",
-		"source=${localWorkspaceFolder}/ssh,target=/root/.ssh,type=bind,consistency=cached",
-	],
-
-	// Use in-container folder (not mounted host directory) as a workspace to speeeeeeed-up the `npx create-react-app` command. See https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/pull/3.
-	// {localWorkspaceFolder} is open folder host path.
-	"workspaceMount": "source=${localWorkspaceFolder},target=/hostdir,type=bind,consistency=cached",
-	"workspaceFolder": "/workspaces",
-	"containerEnv": { 
-		"MOUNTED_HOST_DIR": "${localWorkspaceFolder}",
-		"MOUNTED_HOST_DIR_PATH_IN_CONTAINER": "/hostdir"
-	},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// npm , amplify mock api , 62224 DynamoDB
-	"forwardPorts": [3000,20002],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm install -g @aws-amplify/cli@8.5.1",
-
-	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "node"
-	
-    // docker container name (Identify Dev Containers)
-	"runArgs": [
-        "--name=dev_container"
-    ]
+  "name": "dev-container101",
+  "dockerFile": "Dockerfile",
+  // Add the IDs of extensions you want installed when the container is created.
+  // Git Extension Pack => "donjayamanne.git-extension-pack"
+  // GraphQL => "graphql.vscode-graphql"
+  // GraphQL for VSCode => kumar-harsh.graphql-for-vscode
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shellIntegration.enabled": true
+      },
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "mhutchie.git-graph",
+        "eamodio.gitlens"
+      ]
+    }
+  },
+  // Mount ~/.aws directory for AWS Amplify CLI and AWS CLI access
+  // Mount ~/.ssh directory for Git Repository GitHub, GitLab ...
+  //"source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/root/.aws,type=bind,consistency=cached",
+  //"source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
+  // remoteUser: "root" の場合
+  // "source=${localWorkspaceFolder}/aws,target=/root/.aws,type=bind,consistency=cached",
+  // "source=${localWorkspaceFolder}/ssh,target=/root/.ssh,type=bind,consistency=cached",
+  "mounts": [
+    "source=${localWorkspaceFolder}/aws,target=/home/node/.aws,type=bind,consistency=cached",
+    "source=${localWorkspaceFolder}/ssh,target=/home/node/.ssh,type=bind,consistency=cached",
+  ],
+  // Use in-container folder (not mounted host directory) as a workspace to speeeeeeed-up the `npx create-react-app` command. See https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/pull/3.
+  // {localWorkspaceFolder} is open folder host path.
+  "workspaceMount": "source=${localWorkspaceFolder},target=/hostdir,type=bind,consistency=cached",
+  "workspaceFolder": "/workspaces",
+  "containerEnv": {
+    "MOUNTED_HOST_DIR": "${localWorkspaceFolder}",
+    "MOUNTED_HOST_DIR_PATH_IN_CONTAINER": "/hostdir"
+  },
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // npm , amplify mock api , 62224 DynamoDB
+  "forwardPorts": [
+    3000,
+    20002
+  ],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // RUN su node -c "npm install -g "
+  // "postCreateCommand": "npm install --global @aws-amplify/cli@12.1.1 --unsafe-perm=true",
+  // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+  // See https://github.com/microsoft/vscode-remote-release/issues/7307
+  "remoteUser": "node",
+  // "remoteUser": "root",
+  // docker container name (Identify Dev Containers)
+  "runArgs": [
+    "--name=dev_container_101"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ processors=8 # Makes the WSL 2 VM use two virtual processors ,max 80%
 ```
 - 設定したらDocker Desktopを再起動するか、OSを再起動する
 
+
+## コンテナ内のユーザー
+
+- 以前は、root でしたが、dockerベースイメージ変更され、 node ユーザー がデフォルトになっているため、nodeユーザーを使うようにしています
+- devcontainer.json 内の「"remoteUser": "node"」を root にすると、rootになります
+- remoteUserをrootにする場合
+     - devcontainer.json 内のmountsをrootに合わせて target ディレクトリを変更します（ /home/node/  -> /root/ ）
+     - Dockerfile での RUN を su node をやめて、 root実行されるように変更します（  RUN su node コマンド ->  RUN コマンド）
+
 ## VSCode
 - install Visual Studio Code
     - https://code.visualstudio.com/download
@@ -32,11 +41,13 @@ processors=8 # Makes the WSL 2 VM use two virtual processors ,max 80%
     - `Docker` (ms-azuretools.vscode-docker)
     - Git操作系（ `Git Lens` , `Git Graph`等）
 
+### VS Code Remote Development
+
 ### リモートコンテナを使う
 1. このリポジトリをGit clone または zipダウンロードする
 1. VSCodeから File -> OpenFolder -> this project folder.  `.devcontainer` があるフォルダを開く
     ```
-        C:\xxx\amplify-local-develop-container
+        C:\xxx\aws-amplify-typescript-local-container
             │
             ├─.devcontainer
             │      devcontainer.json
@@ -54,6 +65,9 @@ processors=8 # Makes the WSL 2 VM use two virtual processors ,max 80%
                     known_hosts        
 1. 初回であればコンテナビルドが自動実行される
     - リビルドするとコンテナ内のファイルが消える（なくなる）ので注意
+
+- 上記の 手順で単にエクスプローラー相当で開かれる場合は、VS Code メニュー等で「Reopen In Container」で開く
+
 
 #### リモートコンテナ内の説明
 - VS Codeの拡張機能のremote explorer で、「Open Folder In container」でVSCodeをIDEにしてファイルの編集ができる 
@@ -126,7 +140,8 @@ processors=8 # Makes the WSL 2 VM use two virtual processors ,max 80%
 #### リモートコンテナ系
 - [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 - [Remote - WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl#:~:text=The%20Remote%20%2D%20WSL%20extension%20lets,as%20you%20would%20from%20Windows.)
-
+- [VS Code Remote Development](https://code.visualstudio.com/docs/remote/remote-overview)
+ 
 #### Amplify 系
 - [AWS Amplify API]
 - [AppSync Utils]


### PR DESCRIPTION
- Fromのベースイメージを16から18に変更
-（ベースイメージもrootからnodeに変わっているため）vscodeから起動時のユーザーをrootユーザーからnodeユーザーに変更
- 利用するnode version は デフォルトインストールのまま使う（nvmがデフォルトがインストール済なので、インストール済のnvmを利用する）
- README ; remoteユーザーについて追記